### PR TITLE
Corrected problem with having no rootViewController

### DIFF
--- a/Empty Application.xctemplate/TemplateInfo.plist
+++ b/Empty Application.xctemplate/TemplateInfo.plist
@@ -29,6 +29,7 @@
 						<key>AppDelegate.m:implementation:methods:applicationdidFinishLaunchingWithOptions:body</key>
 						<string>self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
 // Override point for customization after application launch.
+// TODO: Substitute UIViewController with your own subclass.
 self.window.rootViewController = [[UIViewController alloc] init];
 self.window.backgroundColor = [UIColor whiteColor];</string>
 						<key>AppDelegate.m:implementation:methods:applicationdidFinishLaunchingWithOptions:return</key>
@@ -44,6 +45,7 @@ return YES;
 						<key>AppDelegate.swift:implementation:methods:applicationdidFinishLaunchingWithOptions:body</key>
 						<string>self.window = UIWindow(frame: UIScreen.mainScreen().bounds)
 // Override point for customization after application launch.
+// TODO: Substitute UIViewController with your own subclass.
 self.window!.rootViewController = UIViewController()
 self.window!.backgroundColor = UIColor.whiteColor()</string>
 						<key>AppDelegate.swift:implementation:methods:applicationdidFinishLaunchingWithOptions:return</key>

--- a/Empty Application.xctemplate/TemplateInfo.plist
+++ b/Empty Application.xctemplate/TemplateInfo.plist
@@ -29,6 +29,7 @@
 						<key>AppDelegate.m:implementation:methods:applicationdidFinishLaunchingWithOptions:body</key>
 						<string>self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
 // Override point for customization after application launch.
+self.window.rootViewController = [[UIViewController alloc] init];
 self.window.backgroundColor = [UIColor whiteColor];</string>
 						<key>AppDelegate.m:implementation:methods:applicationdidFinishLaunchingWithOptions:return</key>
 						<string>[self.window makeKeyAndVisible];
@@ -43,6 +44,7 @@ return YES;
 						<key>AppDelegate.swift:implementation:methods:applicationdidFinishLaunchingWithOptions:body</key>
 						<string>self.window = UIWindow(frame: UIScreen.mainScreen().bounds)
 // Override point for customization after application launch.
+self.window!.rootViewController = UIViewController()
 self.window!.backgroundColor = UIColor.whiteColor()</string>
 						<key>AppDelegate.swift:implementation:methods:applicationdidFinishLaunchingWithOptions:return</key>
 						<string>self.window!.makeKeyAndVisible()

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ But no need to fret! It isn't difficult to add it back.
 - Clone or download the repo. 
 - Copy the `Empty Application.xctemplate` directory to the following location, `{Xcode.app}/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/Xcode/Templates/Project Templates/iOS/Application/`.
 - Restart Xcode.
+
 or
+
 - Clone or download the repo.
 - Create the `~/Library/Developer/Xcode/Templates/Project Templates/Application/` directory
 - Copy the `Empty Application.xctemplate` directory to `~/Library/Developer/Xcode/Templates/Project Templates/Application/` 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ But no need to fret! It isn't difficult to add it back.
 - Clone or download the repo. 
 - Copy the `Empty Application.xctemplate` directory to the following location, `{Xcode.app}/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/Xcode/Templates/Project Templates/iOS/Application/`.
 - Restart Xcode.
+or
+- Clone or download the repo.
+- Create the `~/Library/Developer/Xcode/Templates/Project Templates/Application/` directory
+- Copy the `Empty Application.xctemplate` directory to `~/Library/Developer/Xcode/Templates/Project Templates/Application/` 
+- Restart Xcode. 
 
-
-
+The second method will avoid Apple overwriting your template but is a per user solution.


### PR DESCRIPTION
This caused a runtime exception and should be implemented in the template by default. So that the project can run with no errors.
